### PR TITLE
strip whitespace from auth, as dpcore did

### DIFF
--- a/dataplicity/client.py
+++ b/dataplicity/client.py
@@ -31,9 +31,9 @@ class Client(object):
 
     @classmethod
     def _read(cls, path):
-        """Read contents of a file."""
+        """Read contents of a file, strip whitespace."""
         with open(path, 'rt') as fh:
-            data = fh.read()
+            data = fh.read().strip()
         return data
 
     def _init(self):


### PR DESCRIPTION
Old dpcore had a newline at the end of auth / serial. Replicate that behavious.