### PR TITLE
Add Python 3.6 to the tox builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,4 +2,4 @@ dependencies:
   override:
     - pip install -r requirements-tests.txt
     - pip install tox tox-pyenv
-    - pyenv local 2.7.11 3.5.2
+    - pyenv local 2.7.11 3.5.2 3.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py{27,35,36}
 
 [testenv]
 passenv = CIRCLE_ARTIFACTS


### PR DESCRIPTION
### What this PR solves
- This adds python 3.6 to the test builds created by tox.

### Review
- [x] Ready for review
