### PR TITLE
add support for dynamically forwarding port on the agent

### DIFF
--- a/dataplicity/m2mmanager.py
+++ b/dataplicity/m2mmanager.py
@@ -271,9 +271,9 @@ class M2MManager(object):
             self.open_echo_service(port)
         elif action == 'open-portforward':
             service = data['service']
-            local_port = int(data.get('port', -1))
+            device_port = data.get('device_port', None)
             route = data['route']
-            self.open_portforward(service, route, local_port=local_port)
+            self.open_portforward(service, route, device_port=device_port)
         elif action == 'reboot-device':
             log.debug('reboot requested')
             self.reboot()
@@ -292,9 +292,9 @@ class M2MManager(object):
         log.debug('opening echo service on m2m port %s', port)
         EchoService(self.m2m_client.get_channel(port))
 
-    def open_portforward(self, service, route, local_port):
+    def open_portforward(self, service, route, device_port=None):
         """Open a port forward service."""
-        self.client.port_forward.open_service(service, route, local_port)
+        self.client.port_forward.open_service(service, route, device_port)
 
     def reboot(self):
         """Initiate a reboot."""

--- a/dataplicity/m2mmanager.py
+++ b/dataplicity/m2mmanager.py
@@ -271,7 +271,7 @@ class M2MManager(object):
             self.open_echo_service(port)
         elif action == 'open-portforward':
             service = data['service']
-            local_port = int(data['port'])
+            local_port = int(data.get('port', -1))
             route = data['route']
             self.open_portforward(service, route, local_port=local_port)
         elif action == 'reboot-device':

--- a/dataplicity/m2mmanager.py
+++ b/dataplicity/m2mmanager.py
@@ -271,8 +271,9 @@ class M2MManager(object):
             self.open_echo_service(port)
         elif action == 'open-portforward':
             service = data['service']
+            local_port = int(data['port'])
             route = data['route']
-            self.open_portforward(service, route)
+            self.open_portforward(service, route, local_port=local_port)
         elif action == 'reboot-device':
             log.debug('reboot requested')
             self.reboot()
@@ -291,9 +292,9 @@ class M2MManager(object):
         log.debug('opening echo service on m2m port %s', port)
         EchoService(self.m2m_client.get_channel(port))
 
-    def open_portforward(self, service, route):
+    def open_portforward(self, service, route, local_port):
         """Open a port forward service."""
-        self.client.port_forward.open_service(service, route)
+        self.client.port_forward.open_service(service, route, local_port)
 
     def reboot(self):
         """Initiate a reboot."""

--- a/dataplicity/m2mmanager.py
+++ b/dataplicity/m2mmanager.py
@@ -273,6 +273,10 @@ class M2MManager(object):
             service = data['service']
             route = data['route']
             self.open_portforward(service, route)
+        elif action == 'open-portredirect':
+            device_port = data['device_port']
+            m2m_port = data['m2m_port']
+            self.client.port_forward.redirect_port(device_port, m2m_port)
         elif action == 'reboot-device':
             log.debug('reboot requested')
             self.reboot()

--- a/dataplicity/m2mmanager.py
+++ b/dataplicity/m2mmanager.py
@@ -271,9 +271,8 @@ class M2MManager(object):
             self.open_echo_service(port)
         elif action == 'open-portforward':
             service = data['service']
-            device_port = data.get('device_port', None)
             route = data['route']
-            self.open_portforward(service, route, device_port=device_port)
+            self.open_portforward(service, route)
         elif action == 'reboot-device':
             log.debug('reboot requested')
             self.reboot()
@@ -292,9 +291,9 @@ class M2MManager(object):
         log.debug('opening echo service on m2m port %s', port)
         EchoService(self.m2m_client.get_channel(port))
 
-    def open_portforward(self, service, route, device_port=None):
+    def open_portforward(self, service, route):
         """Open a port forward service."""
-        self.client.port_forward.open_service(service, route, device_port)
+        self.client.port_forward.open_service(service, route)
 
     def reboot(self):
         """Initiate a reboot."""

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -301,17 +301,28 @@ class PortForwardManager(object):
         self._ports[port] = name
         log.debug("added port forward service '%s' on port %s", name, port)
 
-    def open_service(self, service, route):
+    def open_service(self, service, route, local_port):
         log.debug('opening service %s on %r', service, route)
         node1, port1, node2, port2 = route
-        self.open(port2, service)
+        self.open(port2, service, port=local_port)
 
     def open(self, m2m_port, service=None, port=None):
         """Open a port forward service."""
+        # cache `service` var value, because if the service is not yet
+        # registered, we will loose value of this variable by calling either
+        # `get_service` or `get_service_on_port`
+        service_name = service
+
         if service is None and port is None:
             raise ValueError("one of service or port is required")
         if port is not None:
             service = self.get_service_on_port(port or 80)
         elif service is not None:
             service = self.get_service(service)
+        if service is None:
+            # this service is not yet forwarded.
+            # add it to list of handled services
+            self.add_service(service_name, port)
+            service = self._services[service_name]
+
         service.connect(m2m_port)

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -308,11 +308,6 @@ class PortForwardManager(object):
 
     def open(self, m2m_port, service=None, port=None):
         """Open a port forward service."""
-        # cache `service` var value, because if the service is not yet
-        # registered, we will loose value of this variable by calling either
-        # `get_service` or `get_service_on_port`
-        service_name = service
-
         if service is None and port is None:
             raise ValueError("one of service or port is required")
         if port is not None:
@@ -320,21 +315,12 @@ class PortForwardManager(object):
         elif service is not None:
             service = self.get_service(service)
         if service is None:
-            # this service is not yet forwarded.
-            # add it to list of handled services
-            if '-' not in service_name:
-                raise ValueError(
-                    "you are trying to forward a port, but you haven't"
-                    " specified it"
-                )
+            return
+        service.connect(m2m_port)
 
-            _, portno = service_name.split('-')
-            if not portno.isdigit():
-                raise ValueError(
-                    "you are trying to forward a port, but it is not a"
-                    " number"
-                )
-            self.add_service(service_name, int(portno))
-            service = self._services[service_name]
-
+    def redirect_service(self, m2m_port, device_port):
+        service = Service(
+            manager=self, name='port-{}'.format(device_port),
+            port=device_port, host='127.0.0.1'
+        )
         service.connect(m2m_port)

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -285,7 +285,7 @@ class PortForwardManager(object):
 
     def get_service_on_port(self, port):
         """Get the service on a numbered port."""
-        service_name = self._ports.get('port')
+        service_name = self._ports.get(port)
         if service_name is None:
             return None
         return self._services[service_name]
@@ -316,12 +316,16 @@ class PortForwardManager(object):
         if service is None and port is None:
             raise ValueError("one of service or port is required")
         if port is not None:
+            if port < 0:
+                raise ValueError("you are trying to forward port but you haven't specified it")  # noqa
             service = self.get_service_on_port(port or 80)
         elif service is not None:
             service = self.get_service(service)
         if service is None:
             # this service is not yet forwarded.
             # add it to list of handled services
+            if port < 0:
+                raise ValueError("you are trying to forward port but you haven't specified it")  # noqa
             self.add_service(service_name, port)
             service = self._services[service_name]
 

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -301,10 +301,10 @@ class PortForwardManager(object):
         self._ports[port] = name
         log.debug("added port forward service '%s' on port %s", name, port)
 
-    def open_service(self, service, route, device_port=None):
+    def open_service(self, service, route):
         log.debug('opening service %s on %r', service, route)
         node1, port1, node2, port2 = route
-        self.open(port2, service, port=device_port)
+        self.open(port2, service)
 
     def open(self, m2m_port, service=None, port=None):
         """Open a port forward service."""
@@ -322,9 +322,19 @@ class PortForwardManager(object):
         if service is None:
             # this service is not yet forwarded.
             # add it to list of handled services
-            if not port or (isinstance(port, str) and not port.isdigit()):
-                raise ValueError("you are trying to forward port but you haven't specified it")  # noqa
-            self.add_service(service_name, int(port))
+            if '-' not in service_name:
+                raise ValueError(
+                    "you are trying to forward a port, but you haven't"
+                    " specified it"
+                )
+
+            _, portno = service_name.split('-')
+            if not portno.isdigit():
+                raise ValueError(
+                    "you are trying to forward a port, but it is not a"
+                    " number"
+                )
+            self.add_service(service_name, int(portno))
             service = self._services[service_name]
 
         service.connect(m2m_port)

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -301,10 +301,10 @@ class PortForwardManager(object):
         self._ports[port] = name
         log.debug("added port forward service '%s' on port %s", name, port)
 
-    def open_service(self, service, route, local_port):
+    def open_service(self, service, route, device_port=None):
         log.debug('opening service %s on %r', service, route)
         node1, port1, node2, port2 = route
-        self.open(port2, service, port=local_port)
+        self.open(port2, service, port=device_port)
 
     def open(self, m2m_port, service=None, port=None):
         """Open a port forward service."""
@@ -316,17 +316,15 @@ class PortForwardManager(object):
         if service is None and port is None:
             raise ValueError("one of service or port is required")
         if port is not None:
-            if port < 0:
-                raise ValueError("you are trying to forward port but you haven't specified it")  # noqa
             service = self.get_service_on_port(port or 80)
         elif service is not None:
             service = self.get_service(service)
         if service is None:
             # this service is not yet forwarded.
             # add it to list of handled services
-            if port < 0:
+            if not port or (isinstance(port, str) and not port.isdigit()):
                 raise ValueError("you are trying to forward port but you haven't specified it")  # noqa
-            self.add_service(service_name, port)
+            self.add_service(service_name, int(port))
             service = self._services[service_name]
 
         service.connect(m2m_port)

--- a/tests/dataplicity/test_portforward.py
+++ b/tests/dataplicity/test_portforward.py
@@ -1,0 +1,32 @@
+import pytest
+from mock import patch
+from dataplicity.portforward import Service
+from dataplicity.portforward import PortForwardManager
+
+
+class FakeClient(object):
+    pass
+
+
+@pytest.fixture
+def manager():
+    client = FakeClient()
+    return PortForwardManager(client=client)
+
+
+@pytest.fixture
+def route():
+    return ('node1', 8888, 'node2', 8888)
+
+
+def test_open_service_which_doesnt_exist_yet(manager, route):
+    with patch('dataplicity.portforward.Service.connect') as connect:
+        assert manager.get_service('new-service') is None
+        assert manager.get_service_on_port(1234) is None
+
+        manager.open_service('new-service', route, 1234)
+        # this method will be called at the very end of `open()` call
+        assert connect.called
+        _service = manager.get_service('new-service')
+        assert _service is not None
+        assert isinstance(_service, Service)

--- a/tests/dataplicity/test_portforward.py
+++ b/tests/dataplicity/test_portforward.py
@@ -19,14 +19,13 @@ def route():
     return ('node1', 8888, 'node2', 8888)
 
 
-def test_open_service_which_doesnt_exist_yet(manager, route):
+def test_open_service_which_doesnt_exist_results_in_noop(manager, route):
     with patch('dataplicity.portforward.Service.connect') as connect:
         assert manager.get_service('new-service') is None
         assert manager.get_service_on_port(1234) is None
 
         manager.open_service('port-1234', route)
-        # this method will be called at the very end of `open()` call
-        assert connect.called
-        _service = manager.get_service('port-1234')
-        assert _service is not None
-        assert isinstance(_service, Service)
+        # this method should not be called because it is an unknown service
+        # and therefore the whole action should be turn into a no-op
+
+        assert not connect.called

--- a/tests/dataplicity/test_portforward.py
+++ b/tests/dataplicity/test_portforward.py
@@ -28,3 +28,10 @@ def test_open_service_which_doesnt_exist_results_in_noop(manager, route):
         # and therefore the whole action should be turn into a no-op
 
         assert not connect.called
+
+
+def test_redirect_service(manager, route):
+    with patch('dataplicity.portforward.Service.connect') as connect:
+        manager.redirect_service(9999, 22)
+
+        assert connect.called

--- a/tests/dataplicity/test_portforward.py
+++ b/tests/dataplicity/test_portforward.py
@@ -24,9 +24,9 @@ def test_open_service_which_doesnt_exist_yet(manager, route):
         assert manager.get_service('new-service') is None
         assert manager.get_service_on_port(1234) is None
 
-        manager.open_service('new-service', route, 1234)
+        manager.open_service('port-1234', route)
         # this method will be called at the very end of `open()` call
         assert connect.called
-        _service = manager.get_service('new-service')
+        _service = manager.get_service('port-1234')
         assert _service is not None
         assert isinstance(_service, Service)

--- a/tests/dataplicity/test_portforward.py
+++ b/tests/dataplicity/test_portforward.py
@@ -1,6 +1,5 @@
 import pytest
 from mock import patch
-from dataplicity.portforward import Service
 from dataplicity.portforward import PortForwardManager
 
 


### PR DESCRIPTION
### What this PR solves
- this PR extends the built-in `open-portforward` instruction packet to allow opening ports which are not forwarded by default (in the constructor of `PortForwardManager` class)
### How it is done
- the change expects `open-portforward` instruction to contain `port` attribute, so we can pass it to `add_service` call
### What to look out for
- this PR is supposed to be backward-compatible, so please pay special attention to anything which may break up compatibility
### Screenshots (if appropriate)
-
### Review
- [x] Ready for review
