### PR TITLE
fix redirect-port instruction

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ dependencies:
   override:
     - pip install -r requirements-tests.txt
     - pip install tox tox-pyenv
-    - pyenv local 2.7.11 3.5.2 3.6.0
+    - pyenv local 2.7.11 3.5.2 3.6.2
 test:
   override:
     - tox

--- a/dataplicity/m2mmanager.py
+++ b/dataplicity/m2mmanager.py
@@ -153,7 +153,9 @@ class M2MManager(object):
         elif action == 'open-portredirect':
             device_port = data['device_port']
             m2m_port = data['m2m_port']
-            self.client.port_forward.redirect_port(device_port, m2m_port)
+            self.client.port_forward.redirect_port(
+                device_port=device_port, m2m_port=m2m_port
+            )
         elif action == 'reboot-device':
             self.reboot()
         elif action == 'read-file':

--- a/dataplicity/m2mmanager.py
+++ b/dataplicity/m2mmanager.py
@@ -153,9 +153,7 @@ class M2MManager(object):
         elif action == 'open-portredirect':
             device_port = data['device_port']
             m2m_port = data['m2m_port']
-            self.client.port_forward.redirect_port(
-                device_port=device_port, m2m_port=m2m_port
-            )
+            self.client.port_forward.redirect_port(m2m_port, device_port)
         elif action == 'reboot-device':
             self.reboot()
         elif action == 'read-file':

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -240,7 +240,7 @@ class Service(object):
                 self.close_event,
                 connection_id,
                 channel,
-                self.host_port(),
+                self.host_port,
                 self.on_connection_complete
             )
             self._connections[connection_id] = connection

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -281,7 +281,6 @@ class PortForwardManager(object):
         self._client = weakref.ref(client)
         self._services = {}
         self._ports = {}
-        self._dynamic_ports = {}
         self._close_event = threading.Event()
 
     @property

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -170,7 +170,6 @@ class Connection(threading.Thread):
         else:
             if self.service:
                 log.debug("connected to %s", self.service.url)
-            _socket.setblocking(0)  # set non-blocking
             self.socket = _socket
             self._flush_buffer()
             return True

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -144,7 +144,7 @@ class Connection(threading.Thread):
         # Set the timeout for initial connect, as default is too high
         _socket.settimeout(5.0)
 
-        log.debug('connecting to %s', ':'.join(map(str, self.host_port)))
+        log.debug('connecting to %s:%d', *self.host_port)
         try:
             _socket.connect(self.host_port)
         except socket.timeout:
@@ -157,7 +157,7 @@ class Connection(threading.Thread):
             log.exception('error connecting')
             return False
         else:
-            log.debug("connected to %s", ':'.join(map(str, self.host_port)))
+            log.debug("connected to %s:%d", *self.host_port)
             self.socket = _socket
             self._flush_buffer()
             return True

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -255,6 +255,7 @@ class PortForwardManager(object):
         self._client = weakref.ref(client)
         self._services = {}
         self._ports = {}
+        self._dynamic_ports = {}
         self._close_event = threading.Event()
 
     @property
@@ -317,9 +318,13 @@ class PortForwardManager(object):
             return
         service.connect(m2m_port)
 
-    def redirect_service(self, m2m_port, device_port):
-        service = Service(
-            manager=self, name='port-{}'.format(device_port),
-            port=device_port, host='127.0.0.1'
-        )
+    def redirect_port(self, m2m_port, device_port):
+        if device_port not in self._dynamic_ports:
+            service = Service(
+                manager=self, name='port-{}'.format(device_port),
+                port=device_port, host='127.0.0.1'
+            )
+            self._dynamic_ports[device_port] = service
+        service = self._dynamic_ports[device_port]
         service.connect(m2m_port)
+        return service

--- a/tests/dataplicity/test_portforward.py
+++ b/tests/dataplicity/test_portforward.py
@@ -1,10 +1,7 @@
-import weakref
-
 import pytest
 from dataplicity.m2mmanager import M2MManager
 from dataplicity.portforward import PortForwardManager
 from mock import call, patch
-
 
 _weakref_table = {}
 

--- a/tests/dataplicity/test_portforward.py
+++ b/tests/dataplicity/test_portforward.py
@@ -57,7 +57,7 @@ def test_calling_redirect_service_from_m2mmanager_works():
                 'm2m_port': 1234
             }
         )
-        assert redirect_port.call_args == call(device_port=22, m2m_port=1234)
+        assert redirect_port.call_args == call(1234, 22)
 
 
 def test_can_open_service_by_name(manager):

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,11 @@
 envlist = py{27,35,36}
 
 [testenv]
+usedevelop = true
 passenv = CIRCLE_ARTIFACTS
 setenv = PYTHONPATH={toxinidir}/tests
 deps = -rrequirements-tests.txt
 commands = py.test --cov-config {toxinidir}/.coveragerc \
-        --cov={envsitepackagesdir}/dataplicity \
+        --cov={toxinidir}/dataplicity \
         --cov-report html:{env:CIRCLE_ARTIFACTS:reports}/{envname} \
         {posargs:tests/}


### PR DESCRIPTION
### What this PR solves
there were two problems with current code. First, a typo which was unseen - M2MManager class was calling `PortForwardManager.redirect_port`, but the method was called `redirect_service`. Second of all, there was a problem with weakref created out of dynamic Service, which, when run in thread, was set to None
### How it is done
- a new entry in `PortForwardManager` is created, `_dynamic_ports` to keep track of the references
- two unit test to acompany the above
### What to look out for
- unclean code

### Review
- [x] Ready for review
