### PR TITLE
Set auth and serial from commandline

### DIFF
--- a/dataplicity/app.py
+++ b/dataplicity/app.py
@@ -55,7 +55,11 @@ class App(object):
         parser.add_argument('-m', '--m2m-url', metavar="WS URL", dest="m2m_url", default=None,
                             help="URL of m2m server (should start with ws:// or wss://")
         parser.add_argument('-q', '--quiet', action="store_true", default=False,
-                            help="hide output")
+                            help="Hide output")
+        parser.add_argument('--serial', dest='serial', metavar='SERIAL', default=None,
+                            help='Set Dataplicity serial')
+        parser.add_argument('--auth', dest='auth_token', metavar='KEY', default=None,
+                            help='Set Dataplicity auth token')
 
         subparsers = parser.add_subparsers(title='available sub-commands',
                                            dest="subcommand",
@@ -119,7 +123,9 @@ class App(object):
         """Make the client object."""
         client = Client(
             rpc_url=self.args.server_url,
-            m2m_url=self.args.m2m_url
+            m2m_url=self.args.m2m_url,
+            serial=self.args.serial,
+            auth_token=self.args.auth_token
         )
         return client
 

--- a/dataplicity/client.py
+++ b/dataplicity/client.py
@@ -23,9 +23,11 @@ log = logging.getLogger('agent')
 class Client(object):
     """Dataplicity client."""
 
-    def __init__(self, rpc_url=None, m2m_url=None):
+    def __init__(self, rpc_url=None, m2m_url=None, serial=None, auth_token=None):
         self.rpc_url = rpc_url or constants.SERVER_URL
         self.m2m_url = m2m_url or constants.M2M_URL
+        self.auth_token = auth_token
+        self.serial = serial
         self._sync_lock = Lock()
         self._sent_meta = False
         self.exit_event = Event()
@@ -44,8 +46,8 @@ class Client(object):
             log.info('uname=%s', ' '.join(platform.uname()))
 
             self.remote = jsonrpc.JSONRPC(self.rpc_url)
-            self.serial = self._read(constants.SERIAL_LOCATION)
-            self.auth_token = self._read(constants.AUTH_LOCATION)
+            self.serial = self.serial or self._read(constants.SERIAL_LOCATION)
+            self.auth_token = self.auth_token or self._read(constants.AUTH_LOCATION)
             self.poll_rate_seconds = 60
             self.disk_poll_rate_seconds = 60 * 60
             self.next_disk_poll_time = time.time()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,12 +6,15 @@ description: |
   Dataplicity Agent is a service which enables remote terminals and web
   forwarding from Dataplicity.com
 grade: devel
-confinement: classic
+confinement: devmode
 
 apps:
-  dataplicity:
+  dataplicity-agent:
     command: bin/dataplicity --log-file /var/log/dataplicity.log run
     daemon: simple
+
+  dataplicity:
+    command: bin/dataplicity
 
 parts:
   dataplicity:


### PR DESCRIPTION
This is for me to experiment with the snap. Alas snapcraft will not build from a branch, so it needs to go in to master to play with it.

### What this PR solves
- Allows serial and auth to be specified on the command line

### Review
- [X] Ready for review
