### PR TITLE
Send machine revision instead of machine type

### DIFF
--- a/dataplicity/client.py
+++ b/dataplicity/client.py
@@ -182,9 +182,9 @@ class Client(object):
                 agent_version=meta['agent_version']
             )
             batch.call_with_id(
-                'set_machine_type_result',
-                'device.set_machine_type',
-                machine_type=meta['machine_type'] or 'other'
+                'set_machine_revision_result',
+                'device.set_machine_revision',
+                revision_code=meta['machine_revision']
             )
             batch.call_with_id(
                 'set_os_version_result',
@@ -211,7 +211,7 @@ class Client(object):
         try:
             batch.check(
                 'set_agent_version_result',
-                'set_machine_type_result',
+                'set_machine_revision_result',
                 'set_os_version_result',
                 'set_uname_result'
             )

--- a/dataplicity/device_meta.py
+++ b/dataplicity/device_meta.py
@@ -22,7 +22,7 @@ def get_meta():
         return _META_CACHE.copy()
     meta = {}
     meta['agent_version'] = __version__
-    meta['machine_type'] = rpi.get_machine_type()
+    meta['machine_revision'] = rpi.get_machine_revision()
     meta['os_version'] = get_os_version()
     meta['uname'] = get_uname()
     meta['ip_list'] = get_ip_address_list()

--- a/dataplicity/rpi.py
+++ b/dataplicity/rpi.py
@@ -6,54 +6,16 @@ Raspberry Pi specific tools.
 from __future__ import unicode_literals
 
 
-RPI_REVISIONS = {
-    'beta': 'rpi_1b',
-    '0002': 'rpi_1b',
-    '0003': 'rpi_1b',
-    '0004': 'rpi_1b',
-    '0005': 'rpi_1b',
-    '0006': 'rpi_1b',
-    '0007': 'rpi_1a',
-    '0008': 'rpi_1a',
-    '0009': 'rpi_1a',
-    '000d': 'rpi_1b',
-    '000e': 'rpi_1b',
-    '000f': 'rpi_1b',
-    '0010': 'rpi_1b_plus',
-    '0011': 'rpi_cm',
-    '0012': 'rpi_1a_plus',
-    '0013': 'rpi_1b_plus',
-    '0014': 'rpi_cm',
-    '0015': 'rpi_1a_plus',
-    'a01040': 'rpi_2b',
-    'a01041': 'rpi_2b',
-    'a21041': 'rpi_2b',
-    'a22042': 'rpi_2b',
-    '900021': 'rpi_1a_plus',
-    '900032': 'rpi_1b_plus',
-    '900092': 'rpi_0',
-    '900093': 'rpi_0',
-    '920093': 'rpi_0',
-    '9000c1': 'rpi_0',
-    'a02082': 'rpi_3b',
-    'a22082': 'rpi_3b',
-    'a32082': 'rpi_3b',
-    'a020a0': 'rpi_3_cm',
-}
-
-
-def get_machine_type():
+def get_machine_revision():
     """
-    Get the machine type.
+    Get the machine revision.
 
-    A return value of empty string ('') means 'unknown'.
     A return value of None indicates an error (possibly because its
     not running on an RPI).
-    Otherwise the return value is one of the possible Dataplicity
-    machine type constants.
+    Otherwise the return value is the revision code.
 
     """
-    rpi_version = None
+    revision_code = None
     try:
         with open('/proc/cpuinfo', 'rb') as fp:
             for line in fp:
@@ -63,9 +25,9 @@ def get_machine_type():
                 key = key.strip().lower()
                 value = value.strip().lower()
                 if key == 'revision':
-                    rpi_version = RPI_REVISIONS.get(value, '')
+                    revision_code = value
                     break
     except IOError:
         return None
     else:
-        return rpi_version
+        return revision_code

--- a/tests/dataplicity/test_device_meta.py
+++ b/tests/dataplicity/test_device_meta.py
@@ -19,10 +19,10 @@ def test_get_uname():
         assert ' '.join(fake_uname) == device_meta.get_uname()
 
 
-@patch('dataplicity.rpi.get_machine_type', lambda: '')
+@patch('dataplicity.rpi.get_machine_revision', lambda: '')
 def test_get_meta():
     """ test for get_meta function.
-        as this function calls get_machine_type underneath (which we test
+        as this function calls get_machine_revision underneath (which we test
         separately), we temporarily monkey-patch the output to empty string
     """
     # initially, _META_CACHE should be empty

--- a/tests/dataplicity/test_rpi.py
+++ b/tests/dataplicity/test_rpi.py
@@ -1,4 +1,4 @@
-from dataplicity.rpi import get_machine_type, RPI_REVISIONS
+from dataplicity.rpi import get_machine_revision
 from mock import patch
 import six
 
@@ -44,8 +44,8 @@ class MockOpenContext(object):
         pass
 
 
-def test_get_machine_type():
-    """ test for get_machine_type function
+def test_get_machine_revision():
+    """ test for get_machine_revision function
     """
 
     def mock_open(file_contents):
@@ -65,13 +65,13 @@ def test_get_machine_type():
     def builtin_open_name():
         return '{}.open'.format(six.moves.builtins.__name__)
 
-    for rev, expected_value in six.iteritems(RPI_REVISIONS):
-        with patch(
-            builtin_open_name(),
-            mock_open(REVISION_TEMPLATE % rev),
-            create=True
-        ):
-            assert get_machine_type() == expected_value
+    REVISION = 'abc123'
+    with patch(
+        builtin_open_name(),
+        mock_open(REVISION_TEMPLATE % REVISION),
+        create=True
+    ):
+        assert get_machine_revision() == REVISION
 
     # if the file doesn't exist, the version should be None
     with patch(
@@ -79,4 +79,4 @@ def test_get_machine_type():
         mock_open_ioerror,
         create=True
     ):
-        assert get_machine_type() is None
+        assert get_machine_revision() is None


### PR DESCRIPTION
### What this PR solves
Rather than working out the machine type, we now just parse the cpu_info and send the revision code directly to the server.
### How it is done
-
### What to look out for
-
### Screenshots (if appropriate)
-
### Review
- [x] Ready for review
