### PR TITLE
replace select calls

### DIFF
--- a/dataplicity/m2m/proxy.py
+++ b/dataplicity/m2m/proxy.py
@@ -139,7 +139,12 @@ class Interceptor(object):
 
         reading = True
         while reading:
-            for _fd, event_mask in poll.poll(5 * 1000):
+            try:
+                poll_result = poll.poll(5 * 1000)
+            except Exception as error:
+                log.warning("error in proxy.py poll.poll; %s", error)
+                break
+            for _file_descriptor, event_mask in poll_result:
                 if event_mask & readable_events:
                     data = os.read(master_fd, 1024 * 1024)
                     self.master_read(data)

--- a/dataplicity/m2m/remoteprocess.py
+++ b/dataplicity/m2m/remoteprocess.py
@@ -22,7 +22,7 @@ class PidWaitThread(Thread):
     def __init__(self, command, pid):
         self.command = command
         self.pid = pid
-        super(PidWaitThread, self).__init__()
+        super(PidWaitThread, self).__init__(daemon=True)
 
     def __str__(self):
         return '"%s" (pid=%i)' % (self.command, self.pid)

--- a/dataplicity/m2m/remoteprocess.py
+++ b/dataplicity/m2m/remoteprocess.py
@@ -22,7 +22,8 @@ class PidWaitThread(Thread):
     def __init__(self, command, pid):
         self.command = command
         self.pid = pid
-        super(PidWaitThread, self).__init__(daemon=True)
+        super(PidWaitThread, self).__init__()
+        self.daemon = True
 
     def __str__(self):
         return '"%s" (pid=%i)' % (self.command, self.pid)
@@ -64,6 +65,8 @@ class PidWaitThread(Thread):
                     sent_kill = True
                     log.debug("sending SIGKILL to process %s", self)
                     os.kill(self.pid, signal.SIGKILL)
+        else:
+            log.error("process %s will not die!", self)
 
 
 class RemoteProcess(proxy.Interceptor):
@@ -85,7 +88,7 @@ class RemoteProcess(proxy.Interceptor):
         return self._closed
 
     def __repr__(self):
-        return "RemoteProcess({!r}, {!r}, pid=%i)".format(
+        return "RemoteProcess({!r}, {!r}, pid={})".format(
             self.command, self.channel, self.pid
         )
 

--- a/dataplicity/m2m/remoteprocess.py
+++ b/dataplicity/m2m/remoteprocess.py
@@ -43,8 +43,8 @@ class PidWaitThread(Thread):
         sent_kill = False
         kill_time = 15  # Send a sigkill if process doesn't shut down (in seconds)
         while warnings:
-            # os.WNOHANG flags makes waitpid return immediately if the process is running
             time.sleep(2)
+            # os.WNOHANG flags makes waitpid return immediately if the process is running
             pid, exit_code = os.waitpid(self.pid, os.WNOHANG)
             if pid:
                 # The process has returned an exit code

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -56,11 +56,12 @@ class Connection(threading.Thread):
         error_events = select.POLLERR | select.POLLHUP  #  Error or hang up
         events = readable_events | error_events
         poll = select.poll()
-        poll.register(self.socket.fileno(), events)
         try:
             # Connect to remote host
             if not self._connect():
                 return
+
+            poll.register(self.socket.fileno(), events)
 
             log.debug("entered recv loop")
             # Read all the data we can and write it to the channel

--- a/dataplicity/portforward.py
+++ b/dataplicity/portforward.py
@@ -69,9 +69,9 @@ class Connection(threading.Thread):
                 # or there is an error
                 try:
                     poll_result = poll.poll(5 * 1000)
-                except Exception as e:
+                except Exception as error:
                     # For paranoia only.
-                    log.warning("error %s in select", e)
+                    log.warning("error in portforward.py poll.poll; %s", error)
                     break
                 if self.channel.is_closed:
                     break


### PR DESCRIPTION

- Make waiting for remote process to exit a non-blocking operation.

- Replace select calls with poll to overcome select.selects limitation on number of file descriptors.

- [x] Ready for review
