### PR TITLE
Add bumpversion config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 0.5.7
+commit = True
+tag = True
+
+[bumpversion:file:dataplicity/_version.py]


### PR DESCRIPTION
### What this PR solves
- Add bumpversion config file for easier bumpin'
### How it is done
- bump2version is already in the requirements. Let's facilitate its use by defining some configs
### What to look out for
-
### Screenshots (if appropriate)
-
### Review
- [ ] Ready for review
