### PR TITLE
fix python 3.11 deprecated function

### DIFF
--- a/dataplicity/compat.py
+++ b/dataplicity/compat.py
@@ -57,6 +57,7 @@ if PY2:
     from urllib2 import urlopen, HTTPError
     import Queue as queue
     from urllib2 import Request
+    from inspect import getargspec as getfullargspec
 else:
     from urllib.parse import urlparse, parse_qs, urlunparse
     from urllib.parse import urlencode, quote
@@ -64,6 +65,7 @@ else:
     from urllib.request import urlopen, HTTPError
     import queue
     from urllib.request import Request
+    from inspect import getfullargspec
 
 
 # pickle is the C version on PY3

--- a/dataplicity/m2m/dispatcher.py
+++ b/dataplicity/m2m/dispatcher.py
@@ -7,7 +7,7 @@ Dispatches incoming packets
 """
 
 
-from ..compat import text_type
+from ..compat import text_type, getfullargspec
 
 import logging
 import inspect
@@ -92,7 +92,8 @@ class Dispatcher(object):
             self.on_missing_handler(packet)
             return None
 
-        arg_spec = inspect.getargspec(method)
+        arg_spec = getfullargspec(method)
+
         args, kwargs = packet.get_method_args(len(arg_spec[0]))
 
         try:


### PR DESCRIPTION
### What this PR solves
- fixees function that was deprecated since python 3.3 and finally removed now. 
> AttributeError: 'module' object has no attribute 'getfullargspec'

### How it is done
-
### What to look out for
-
### Screenshots (if appropriate)
-
### Review
- [ ] Ready for review
