### PR TITLE
Adding model name to host device

### DIFF
--- a/dataplicity/client.py
+++ b/dataplicity/client.py
@@ -268,6 +268,11 @@ class Client(object):
                 revision_code=meta["machine_revision"],
             )
             batch.call_with_id(
+                "set_model_name_result",
+                "device.set_model_name",
+                model_name=meta["model_name"],
+            )
+            batch.call_with_id(
                 "set_os_version_result",
                 "device.set_os_version",
                 os_version=meta["os_version"],
@@ -291,6 +296,7 @@ class Client(object):
             batch.check(
                 "set_agent_version_result",
                 "set_machine_revision_result",
+                "set_model_name_result",
                 "set_os_version_result",
                 "set_uname_result",
                 "set_ip_addresses_result",

--- a/dataplicity/device_meta.py
+++ b/dataplicity/device_meta.py
@@ -24,6 +24,7 @@ def get_meta():
     meta = {}
     meta["agent_version"] = __version__
     meta["machine_revision"] = rpi.get_machine_revision()
+    meta["model_name"] = rpi.get_model_name()
     meta["os_version"] = get_os_version()
     meta["uname"] = get_uname()
     meta["ip_list"] = get_ip_address_list()

--- a/dataplicity/rpi.py
+++ b/dataplicity/rpi.py
@@ -33,3 +33,15 @@ def get_machine_revision():
         if isinstance(revision_code, bytes):
             return revision_code.decode("utf-8")
         return revision_code
+
+
+def get_model_name():
+    """
+    /proc/device-tree itself is a symlink to /sys/firmware/devicetree/base
+    :return:
+    """
+    try:
+        with open("/proc/device-tree/model", "rb") as fp:
+            return fp.read().decode("utf-8")
+    except IOError:
+        return ""


### PR DESCRIPTION
### What this PR solves
Added model name information (to mark non-RPi devices)

### How it is done
Using /proc/device-tree/model 

### What to look out for
-
### Screenshots (if appropriate)
-
### Review
- [ ] Ready for review
